### PR TITLE
Make "Join Meeting" button reachable via tab key

### DIFF
--- a/webapp/components/post_type_bbb/post_type_bbb.jsx
+++ b/webapp/components/post_type_bbb/post_type_bbb.jsx
@@ -264,12 +264,12 @@ export default class PostTypebbb extends React.PureComponent {
 
         </div>
         <span >
-          <a className='btn btn-lg btn-primary' style={style.button} onClick={this.getJoinURL}>
+          <a className='btn btn-lg btn-primary' style={style.button} onClick={this.getJoinURL} href='#'>
 
             {'Join Meeting'}
           </a>
           {
-            this.props.currentUserId == this.props.creatorId && <a className='btn btn-lg btn-link' style={style.buttonEnd} onClick={this.endMeeting}>
+            this.props.currentUserId == this.props.creatorId && <a className='btn btn-lg btn-link' style={style.buttonEnd} onClick={this.endMeeting} href='#'>
                 <i style={style.buttonIcon}/> {'End meeting'}
               </a>
           }


### PR DESCRIPTION
The _Join Meeting_ and _End meeting_ links do not have `href` attributes, which makes it impossible to navigate to them by hitting the tab key on the keyboard. This makes it difficult for users of screen readers to join meetings. This pull request simply adds a dummy attribute; its value does not really matter as the `onClick` takes precedence.