### PR TITLE
Fix race condition when opening meeting tab

### DIFF
--- a/webapp/components/post_type_bbb/post_type_bbb.jsx
+++ b/webapp/components/post_type_bbb/post_type_bbb.jsx
@@ -112,10 +112,15 @@ export default class PostTypebbb extends React.PureComponent {
       myvar = await myurl.data.joinurl.url;
       window.open(myvar);
     }else{ //for webapps to circumvent popup blockers
-      var newtab = await window.open('https://blindsidenetworks.com/', '_blank');
-      myurl = await this.props.actions.getJoinURL(this.props.channelId, this.props.post.props.meeting_id, this.props.creatorId);
-      myvar = await myurl.data.joinurl.url;
-      newtab.location.href = myvar;
+      var newtab = await window.open('about:blank');
+      try {
+        var myurl = await this.props.actions.getJoinURL(this.props.channelId, this.props.post.props.meeting_id, this.props.creatorId);
+        myvar = await myurl.data.joinurl.url;
+        newtab.location = myvar;
+        newtab.focus();
+      } catch(e) {
+        newtab.close();
+      }
     }
 
     await this.setState({

--- a/webapp/components/root/root.jsx
+++ b/webapp/components/root/root.jsx
@@ -114,10 +114,15 @@ export default class Root extends React.PureComponent {
       myvar = await myurl.data.joinurl.url;
       window.open(myvar);
     }else{ //for webapps to circumvent popup blockers
-      var newtab = await window.open('https://blindsidenetworks.com/', '_blank');
-      var myurl = await this.props.actions.getJoinURL(this.state.channelId, this.state.meetingId, "");
-      myvar = await myurl.data.joinurl.url;
-      newtab.location.href = myvar;
+      var newtab = await window.open('about:blank');
+      try {
+        var myurl = await this.props.actions.getJoinURL(this.state.channelId, this.state.meetingId, "");
+        myvar = await myurl.data.joinurl.url;
+        newtab.location = myvar;
+        newtab.focus();
+      } catch(e) {
+        newtab.close();
+      }
     }
   }
   getSiteUrl = () => {


### PR DESCRIPTION
Clicking on "Join Meeting" would sometimes redirect to the
blindsidenetworks website, especially on chrome.  Fix this by opening
about:blank instead.

While we're at it, properly handle error conditions when joining the
meeting doesn't work.

Note: changing `post_type_bbb.jsx` was enough to solve the bug.  However,
there is very similar code in `root.jsx`, so I also fixed the issue there
(just in case).

Tested with Firefox 75 and Chromium 81.

Fixes #85