### PR TITLE
Implement Admin=Moderator mode

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -23,6 +23,13 @@
         "type": "text",
         "default": "8cd8ef52e8e101574e400365b55e11a6",
         "help_text": "The secret you generated to securely connect to your BigBlueButton. Default for test-install is: 8cd8ef52e8e101574e400365b55e11a6\n"
+      },
+      {
+        "key": "ADMINONLY",
+        "display_name": "Only Admins become Moderators",
+        "type": "bool",
+        "default": "false",
+        "help_text": "Only TeamAdmin accounts will become Moderators in BigBlueButton, everybody else will be attendee. The creator will always be Moderator of a Room.\n"
       }
     ],
     "footer": "All form fields must be filled or the plugin will fail to work. Deactivate and reactivate your plugin when changing to a configuration value. Don't worry, no data will be lost"

--- a/server/config.go
+++ b/server/config.go
@@ -24,6 +24,7 @@ import (
 type Configuration struct {
 	BaseURL string `json:"BASE_URL"`
 	Secret  string `json:"SALT"`
+	AdminOnly bool `json:"ADMINONLY"`
 }
 
 func (p *Plugin) OnConfigurationChange() error {


### PR DESCRIPTION
If AdminOnly toggle is on, only Team Admins/System Admins as well as
the creator will will be moderator in the BBB channel, everybody else
will be atendee.

fixes mattermost-plugin-bigbluebutton/#92

I have problems building the plugin against recent mattermost-server api. He constantly builds against v5.11.1+incompatible which I just can't figure out where it's coming from. Using v5.23.0 or something after v5.18 in the glide.yaml does not work, at least with go 1.13 due the go.mod file in mattermost-server.
go has become the new dependency hell power masochist tool I fear. How do you build a plugin that is equal to the released one, because this works with csrf checks. When I build it uses the 5.11 api I guess, which does not implement them and will therefor fail.