### PR TITLE
Remove meetings without recordings from recording queue after a few hours

### DIFF
--- a/server/responsehandlers.go
+++ b/server/responsehandlers.go
@@ -552,6 +552,7 @@ func (p *Plugin) Loopthroughrecordings() {
 			i--
 			continue
 		}
+		Meeting.LoopCount++
 
 		recordingsresponse, _, _ := bbbAPI.GetRecordings(Meeting.MeetingID_, "", "")
 		if recordingsresponse.ReturnCode == "SUCCESS" {


### PR DESCRIPTION
It seems like meetings without recordings are never removed from the plugin's recording queue. I am currently seeing hundreds of messages like
```
{"level":"info","ts":1591090363.608135,"caller":"mlog/sugar.go:19","msg":"Successfully got recordings info","plugin_id":"bigbluebutton"}
```
in the Mattermost log every two minutes. Looking at the code, i can see that the loop counter is never incremented anywhere, so the check that removes a meeting from the queue after 144 iterations (approximately 4 hours and 48 minutes) never fires. This pull request fixes that.