### PR TITLE
Fix CSRF Check failed for request error

### DIFF
--- a/webapp/client/client.js
+++ b/webapp/client/client.js
@@ -74,7 +74,10 @@ export default class Client {
   }
 
   doPost = async (url, body, headers = {}) => {
-    const options = Client4.getOptions({headers});
+    const options = Client4.getOptions({
+        method: 'post',
+        headers,
+    });
 
     try {
       const response = await request.post(url).send(body).set(options.headers).type('application/json').accept('application/json');

--- a/webapp/client/client.js
+++ b/webapp/client/client.js
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import {Client4} from 'mattermost-redux/client';
+
 import request from 'superagent';
 //superagent helps make post request
 
@@ -72,10 +74,10 @@ export default class Client {
   }
 
   doPost = async (url, body, headers = {}) => {
-    headers['X-Requested-With'] = 'XMLHttpRequest';
+    const options = Client4.getOptions({headers});
 
     try {
-      const response = await request.post(url).send(body).set(headers).type('application/json').accept('application/json');
+      const response = await request.post(url).send(body).set(options.headers).type('application/json').accept('application/json');
 
       return response.body;
     } catch (err) {


### PR DESCRIPTION
Changes to resolve the "CSRF Check failed for request - Please migrate your plugin to either send a CSRF Header or Form Field, XMLHttpRequest is deprecated" errors in the log.