### PR TITLE
Fix meetingroom create url parameters

### DIFF
--- a/server/bigbluebuttonapiwrapper/api/APIcalls.go
+++ b/server/bigbluebuttonapiwrapper/api/APIcalls.go
@@ -72,11 +72,11 @@ func CreateMeeting(meetingRoom *dataStructs.MeetingRoom) (string, error) {
 		url.QueryEscape(strconv.FormatBool(meetingRoom.AllowStartStopRecording))
 	moderatorOnlyMessage := "&moderatorOnlyMessage=" +
 		url.QueryEscape(meetingRoom.ModeratorOnlyMessage)
-	metaBnRecordingReadyUrl := "&meta_bn-recording-ready-url=" +
-		url.QueryEscape(meetingRoom.Meta_bn_recording_ready_url)
+	metaBBBRecordingReadyURL := "&meta_bbb-recording-ready-url=" +
+		url.QueryEscape(meetingRoom.Meta_bn_recording_ready_url)  # TODO: Fix name in Meetingroom struct
 	metaChannelId := "&meta_channelid=" +
 		url.QueryEscape(meetingRoom.Meta_channelid)
-	metaEndcallback := "&meta_endcallbackurl=" +
+	metaEndCallbackURL := "&meta_endCallbackUrl=" +
 		url.QueryEscape(meetingRoom.Meta_endcallbackurl)
 	voiceBridge := "&voiceBridge=" + url.QueryEscape(meetingRoom.VoiceBridge)
 
@@ -85,8 +85,8 @@ func CreateMeeting(meetingRoom *dataStructs.MeetingRoom) (string, error) {
 		"&meta_bbb-origin-server-name=" + url.QueryEscape(meetingRoom.Meta_bbb_origin_server_name)
 
 	createParam := name + meetingID + attendeePW + moderatorPW + welcome + dialNumber +
-		voiceBridge + logoutURL + record + duration + moderatorOnlyMessage + metaBnRecordingReadyUrl + metaChannelId +
-		metaEndcallback + allowStartStopRecording + metaBBBOrigin
+		voiceBridge + logoutURL + record + duration + moderatorOnlyMessage + metaBBBRecordingReadyURL +
+		metaChannelId + metaEndCallbackURL + allowStartStopRecording + metaBBBOrigin
 
 	checksum := helpers.GetChecksum("create" + createParam + secret)
 


### PR DESCRIPTION
For `bbb-recording-ready-url`:
Apparently, this was earlier mis-typed as bn-recording-ready-url in the
BBB documentation and fixed some time ago
(https://github.com/bigbluebutton/bigbluebutton/issues/8216).

For now, I just changed the name of the URL parameter and not also the
member name in the Meetingroom struct, because that would require some
conversion code between the two variants, when loading older
meetingrooms from the database.

For `endCallbackUrl`:
Also, I changed the camelCase of endCallbackUrl so it is in line with
what the API docs say at
https://docs.bigbluebutton.org/dev/api.html#end-meeting-callback-url.