### PR TITLE
Add additional meta field to room creation

### DIFF
--- a/server/bigbluebuttonapiwrapper/api/APIcalls.go
+++ b/server/bigbluebuttonapiwrapper/api/APIcalls.go
@@ -84,9 +84,11 @@ func CreateMeeting(meetingRoom *dataStructs.MeetingRoom) (string, error) {
 		"&meta_bbb-origin-version=" + url.QueryEscape(meetingRoom.Meta_bbb_origin_version) +
 		"&meta_bbb-origin-server-name=" + url.QueryEscape(meetingRoom.Meta_bbb_origin_server_name)
 
+	metaDC := "&meta_dc-creator=" + url.QueryEscape(meetingRoom.Meta_dc_creator)
+
 	createParam := name + meetingID + attendeePW + moderatorPW + welcome + dialNumber +
 		voiceBridge + logoutURL + record + duration + moderatorOnlyMessage + metaBnRecordingReadyUrl + metaChannelId +
-		metaEndcallback + allowStartStopRecording + metaBBBOrigin
+		metaEndcallback + allowStartStopRecording + metaBBBOrigin + metaDC
 
 	checksum := helpers.GetChecksum("create" + createParam + secret)
 

--- a/server/bigbluebuttonapiwrapper/dataStructs/objects.go
+++ b/server/bigbluebuttonapiwrapper/dataStructs/objects.go
@@ -93,6 +93,8 @@ type MeetingRoom struct {
 	Meta_bbb_origin_version     string
 	Meta_bbb_origin_server_name string
 
+	Meta_dc_creator	string
+
 	CreateMeetingResponse CreateMeetingResponse
 	MeetingInfo           GetMeetingInfoResponse
 }

--- a/server/helpers.go
+++ b/server/helpers.go
@@ -38,7 +38,7 @@ const (
 	prefixMeetingList = "m_list_"
 )
 
-func (p *Plugin) PopulateMeeting(m *dataStructs.MeetingRoom, details []string, description string, channelId string) error {
+func (p *Plugin) PopulateMeeting(m *dataStructs.MeetingRoom, details []string, description string, UserId string, channelId string) error {
 	if len(details) == 2 {
 		m.Name_ = details[1]
 	} else {
@@ -94,6 +94,12 @@ func (p *Plugin) PopulateMeeting(m *dataStructs.MeetingRoom, details []string, d
 	} else {
 		return errors.New("SiteURL not set")
 	}
+
+	user, err := p.API.GetUser(UserId)
+	if err != nil {
+		return errors.New("Error resolving UserId")
+	}
+	m.Meta_dc_creator = user.Email
 
 	return nil
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -122,7 +122,7 @@ func (p *Plugin) schedule() error {
 func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
 	meetingpointer := new(dataStructs.MeetingRoom)
 
-	if err := p.PopulateMeeting(meetingpointer, nil, "", args.ChannelId); err != nil {
+	if err := p.PopulateMeeting(meetingpointer, nil, "", args.UserId, args.ChannelId); err != nil {
 		return nil, model.NewAppError("ExecuteCommand", "Please provide a 'Site URL' in Settings > General > Configuration", nil, err.Error(), http.StatusInternalServerError)
 	}
 

--- a/server/responsehandlers.go
+++ b/server/responsehandlers.go
@@ -186,9 +186,9 @@ func (p *Plugin) handleCreateMeeting(w http.ResponseWriter, r *http.Request) {
 	meetingpointer := new(dataStructs.MeetingRoom)
 	var err error
 	if request.Topic == "" {
-		err = p.PopulateMeeting(meetingpointer, nil, request.Desc, request.ChannelId)
+		err = p.PopulateMeeting(meetingpointer, nil, request.Desc, request.UserId, request.ChannelId)
 	} else {
-		err = p.PopulateMeeting(meetingpointer, []string{"create", request.Topic}, request.Desc, request.ChannelId)
+		err = p.PopulateMeeting(meetingpointer, []string{"create", request.Topic}, request.Desc, request.UserId, request.ChannelId)
 	}
 
 	if err != nil {


### PR DESCRIPTION
For starters, I add the `dc-creator` field containing an email address of
the person responsible for starting the room, so when cleaning up
recordings on the BBB server, there is a pointer to who to contact about
a specific recording.

This is in line with at least the OpenOLAT integration which does this here:
https://github.com/OpenOLAT/OpenOLAT/blob/258561c4ee32b2259c84975129bd098b123a8643/src/main/java/org/olat/modules/bigbluebutton/manager/BigBlueButtonNativeRecordingsHandler.java#L127