### PR TITLE
Fixed a bug where delete recording confirmation didn't show submit button on mobile devices

### DIFF
--- a/server/responsehandlers.go
+++ b/server/responsehandlers.go
@@ -731,6 +731,7 @@ func (p *Plugin) handleDeleteRecordingsConfirmation(w http.ResponseWriter, r *ht
 			Title:            "Confirm recording deletion.",
 			IntroductionText: "Once deleted, the recording will be gone forever.\nThis action is irreversible.",
 			State:            string(rawContext),
+			SubmitLabel:      "Submit",
 			Elements: []model.DialogElement{
 				{
 					DisplayName: "Are you sure?",


### PR DESCRIPTION
Fixed a bug where delete recording confirmation didn't show submit button on mobile devices

**Before-**
<img height="800px" src="https://user-images.githubusercontent.com/18575143/125870725-8b4df62b-8206-40c7-9eb2-0590cb3382db.jpg"/>

**After-**
<img height="800px" src="https://user-images.githubusercontent.com/18575143/126315970-0f832833-e844-4c6c-8f31-ba25c3b94654.jpg"/>